### PR TITLE
Feat: implement swapping question card and mock updateQuestionSequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^18",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-debounce": "^10.0.1",
     "vaul": "^0.9.1",
     "zustand": "^4.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^11.3.4",
     "lucide-react": "^0.407.0",
     "next": "14.2.4",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.4)
+      use-debounce:
+        specifier: ^10.0.1
+        version: 10.0.1(react@18.3.1)
       vaul:
         specifier: ^0.9.1
         version: 0.9.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5550,6 +5553,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-debounce@10.0.1:
+    resolution: {integrity: sha512-0uUXjOfm44e6z4LZ/woZvkM8FwV1wiuoB6xnrrOmeAEjRDDzTLQNRFtYHvqUsJdrz1X37j0rVGIVp144GLHGKg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   use-sidecar@1.1.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
@@ -12315,6 +12324,10 @@ snapshots:
       tslib: 2.6.3
     optionalDependencies:
       '@types/react': 18.3.3
+
+  use-debounce@10.0.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sidecar@1.1.2(@types/react@18.3.3)(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      framer-motion:
+        specifier: ^11.3.4
+        version: 11.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react:
         specifier: ^0.407.0
         version: 0.407.0(react@18.3.1)
@@ -3335,6 +3338,20 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  framer-motion@11.3.4:
+    resolution: {integrity: sha512-LC+luwNmz4zEg0AU0rol3yLUFKSJ9GDmIyvigXBAwEbUBG59EWmcRQ2Xh+0py7IkmvWxFUH0TN42v1Dda8xgUg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -9975,6 +9992,13 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@4.3.7: {}
+
+  framer-motion@11.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      tslib: 2.6.3
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
 

--- a/src/app/endpoint.ts
+++ b/src/app/endpoint.ts
@@ -1,1 +1,0 @@
-const BASE_URL = 'http://localhost:3000/api';

--- a/src/app/sub/workbookDetail/[workbookId]/page.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/page.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'next/navigation';
 import Header from '@/app/sub/workbookDetail/[workbookId]/header';
 import WorkbookInformation from '@/app/sub/workbookDetail/[workbookId]/workbook-information';
 import WorkbookEditButtons from '@/app/sub/workbookDetail/[workbookId]/workbook-edit-buttons';
-import WorkbookQuestions from '@/app/sub/workbookDetail/[workbookId]/workbook-questions';
+import WorkbookQuestionArea from '@/app/sub/workbookDetail/[workbookId]/workbook-question-area';
 
 const Page = () => {
   const params = useParams<{ workbookId: string }>();
@@ -14,7 +14,7 @@ const Page = () => {
       <Header />
       <WorkbookInformation />
       <WorkbookEditButtons />
-      <WorkbookQuestions />
+      <WorkbookQuestionArea />
     </div>
   );
 };

--- a/src/app/sub/workbookDetail/[workbookId]/question-card.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/question-card.tsx
@@ -1,8 +1,16 @@
 import React, { useState } from 'react';
 import { QuestionInWorkbook } from '@/app/types';
+import { Reorder, useDragControls } from 'framer-motion';
 
-const QuestionCard = ({ question }: { question: QuestionInWorkbook }) => {
+const QuestionCard = ({
+  question,
+  handleDrag,
+}: {
+  question: QuestionInWorkbook;
+  handleDrag?: React.PointerEventHandler<HTMLButtonElement>;
+}) => {
   const [isExpanded, setExpanded] = useState<boolean>(false);
+  const controls = useDragControls();
 
   const handleExpandToggleClick: React.MouseEventHandler<
     HTMLButtonElement
@@ -10,42 +18,58 @@ const QuestionCard = ({ question }: { question: QuestionInWorkbook }) => {
     setExpanded((prev) => !prev);
   };
 
+  const handleDragPointerDown: React.PointerEventHandler<HTMLButtonElement> = (
+    e,
+  ) => controls.start(e);
+
   if (!isExpanded) {
     return (
-      <div className="flex p-4 border-[1px]">
-        <button onClick={handleExpandToggleClick}>▶️</button>
-        <p>{`Q${question.sequence}`}</p>
-        <p>{question.category}</p>
-        {question.tags.map((tag, idx) => (
-          <p key={idx}>{tag}</p>
-        ))}
-        <p>{question.statement}</p>
-        <button>=</button>
-      </div>
-    );
-  } else {
-    return (
-      <div className="flex flex-col p-4 border-[1px]">
-        <div className="flex">
-          <button onClick={handleExpandToggleClick}>🔽</button>
+      <Reorder.Item
+        value={question}
+        dragListener={false}
+        dragControls={controls}
+      >
+        <div className="flex p-4 border-[1px]">
+          <button onClick={handleExpandToggleClick}>▶️</button>
           <p>{`Q${question.sequence}`}</p>
           <p>{question.category}</p>
           {question.tags.map((tag, idx) => (
             <p key={idx}>{tag}</p>
           ))}
           <p>{question.statement}</p>
-          <button>ℹ️</button>
+          <button onPointerDown={handleDragPointerDown}>=</button>
         </div>
-        <img src={question.image} alt="사진 로드 실패" />
-        <div>문제 설명</div>
-        <p>{question.statement}</p>
-        <div>선택지</div>
-        <div className="flex">
-          {question.options.map((option, idx) => (
-            <p key={idx}>{`${idx + 1} ${option}`}</p>
-          ))}
+      </Reorder.Item>
+    );
+  } else {
+    return (
+      <Reorder.Item
+        value={question}
+        dragListener={false}
+        dragControls={controls}
+      >
+        <div className="flex flex-col p-4 border-[1px]">
+          <div className="flex">
+            <button onClick={handleExpandToggleClick}>🔽</button>
+            <p>{`Q${question.sequence}`}</p>
+            <p>{question.category}</p>
+            {question.tags.map((tag, idx) => (
+              <p key={idx}>{tag}</p>
+            ))}
+            <p>{question.statement}</p>
+            <button>ℹ️</button>
+          </div>
+          <img src={question.image} alt="사진 로드 실패" />
+          <div>문제 설명</div>
+          <p>{question.statement}</p>
+          <div>선택지</div>
+          <div className="flex">
+            {question.options.map((option, idx) => (
+              <p key={idx}>{`${idx + 1} ${option}`}</p>
+            ))}
+          </div>
         </div>
-      </div>
+      </Reorder.Item>
     );
   }
 };

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-question-area.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-question-area.tsx
@@ -1,11 +1,11 @@
-import QuestionCard from '@/app/sub/workbookDetail/[workbookId]/question-card';
 import React, { useEffect, useState } from 'react';
 import { QuestionInWorkbook, Status } from '@/app/types';
 import { useParams } from 'next/navigation';
 import { BASE_URL } from '@/app/constants';
 import { Reorder } from 'framer-motion';
+import QuestionCards from '@/app/sub/workbookDetail/[workbookId]/question-card';
 
-const WorkbookQuestions = () => {
+const WorkbookQuestionArea = () => {
   const [status, setStatus] = useState<Status>('loading');
   const [questions, setQuestions] = useState<QuestionInWorkbook[]>([]);
   const params = useParams<{ workbookId: string }>();
@@ -20,10 +20,13 @@ const WorkbookQuestions = () => {
       .catch((err) => setStatus('error'));
   }, []);
 
+  useEffect(() => {}, [questions]);
+
   if (status === 'loading') return <div>loading..</div>;
   else if (status === 'error') return <div>Question Data fetch Error</div>;
+
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div>
       <Reorder.Group
         axis="y"
         onReorder={setQuestions}
@@ -31,12 +34,10 @@ const WorkbookQuestions = () => {
         layoutScroll
         style={{ overflowY: 'scroll' }}
       >
-        {questions.map((ques) => (
-          <QuestionCard key={ques.id} question={ques} />
-        ))}
+        <QuestionCards questions={questions} />
       </Reorder.Group>
     </div>
   );
 };
 
-export default WorkbookQuestions;
+export default WorkbookQuestionArea;

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
@@ -1,8 +1,9 @@
 import QuestionCard from '@/app/sub/workbookDetail/[workbookId]/question-card';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { QuestionInWorkbook, Status } from '@/app/types';
 import { useParams } from 'next/navigation';
 import { BASE_URL } from '@/app/constants';
+import { Reorder } from 'framer-motion';
 
 const WorkbookQuestions = () => {
   const [status, setStatus] = useState<Status>('loading');
@@ -23,9 +24,17 @@ const WorkbookQuestions = () => {
   else if (status === 'error') return <div>Question Data fetch Error</div>;
   return (
     <div className="flex flex-col gap-4 p-4">
-      {questions.map((ques) => (
-        <QuestionCard key={ques.id} question={ques} />
-      ))}
+      <Reorder.Group
+        axis="y"
+        onReorder={setQuestions}
+        values={questions}
+        layoutScroll
+        style={{ overflowY: 'scroll' }}
+      >
+        {questions.map((ques) => (
+          <QuestionCard key={ques.id} question={ques} />
+        ))}
+      </Reorder.Group>
     </div>
   );
 };

--- a/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
@@ -45,12 +45,18 @@ export const Success: Story = {
             status: 200,
           });
         }),
+        http.patch(`${BASE_URL}/workbook/question-sequence/1`, () => {
+          return HttpResponse.json({
+            result: 'SUCCESS',
+            status: 200,
+          });
+        }),
       ],
     },
   },
 };
 
-export const FailReadingWorkbookAndQuestion: Story = {
+export const FailReadingWorkbookAndQuestionAndDeletingWorkbook: Story = {
   parameters: {
     msw: {
       handlers: [
@@ -71,16 +77,20 @@ export const FailReadingWorkbookAndQuestion: Story = {
   },
 };
 
-export const FailDeletingWorkbookById: Story = {
+export const FailSwappingQuestion: Story = {
   parameters: {
     msw: {
       handlers: [
         http.get(`${BASE_URL}/workbook/1`, () => {
           return HttpResponse.json(Dummy_Workbook);
         }),
+        http.get(`${BASE_URL}/workbook/questions/1`, () => {
+          return HttpResponse.json(Dummy_Questions_In_Workbook);
+        }),
         http.delete(`${BASE_URL}/workbook/1`, () => {
-          return new HttpResponse(null, {
-            status: 403,
+          return HttpResponse.json({
+            result: 'SUCCESS',
+            status: 200,
           });
         }),
       ],


### PR DESCRIPTION
### 🤔 Description
* 문제집 내 문제들의 순서를 drag&drop으로 변경하고 `updateQuestionSequence` API를 호출하는 기능을 구현한다. 추가적으로 매 변경마다 API 호출의 발생을 방지하기 위해 debounce를 적용시킨다.

* drag&drop 구현의 경우 [Reorder - Framer Motion](https://www.framer.com/motion/reorder/)를 사용했으며, debounce는 Next.JS 공식문서의 예제에 따라 [use-debounce](https://github.com/xnimorz/use-debounce?tab=readme-ov-file#debounced-callbacks)를 이용했다.

### 👋 Related issues
* **Close** #21 

### 🔍 Details
* 다음 화면은 `storybook > WorkbookDetail > Success`이다. 화면의 `API calls` 뒤의 숫자가 `updateQuestionSequence`의 호출이 발생한 횟수이다.

  <p align="center"><img src="https://github.com/user-attachments/assets/e8df87cb-b2c5-43c8-b701-def0ab3d7da9"/></p>

  Swap event 발생 후, 일정 시간의 swap event 발생이 없어야 API가 호출되는 방식이다.

* 현재 컴포넌트의 구조는 다음과 같다.
  
  **`workbook-question-area.tsx`**
  * `readQuestionsInWorkbook` 호출 후, 문제 정보를 `<QuestionCards>`에 전달
  * drag&drop을 위한 `<Reorder.Group>` 정의됨
  
  **`question-card.tsx`**
  * 내부에 `<QuestionCards>`와 `<QuestionCard>` 모두 정의됨
  * `<QuestionCards>` 내에서 `<QuestionCard>`를 `map`으로 렌더링 및 `updateQuestionSequence` 호출
  * `<QuestionCard>`에서 drag&drop을 위한 `<Reoder.Item>` 정의됨

### 🐛 Bugs
* 버그는 아니지만 드럽게 짠 부분이 있으니 아래 Others 참고.

### 💬 Others
* 먼저 위와 같이 컴포넌트 구조를 생성한 가장 큰 이유는 하나의 component에서 최대 하나의 API를 호출하기 위해서인데 이에 대한 의견이 궁금함! 🤔

* 또한 현재 `updateQuestionSequence`는 다음과 같이 `useEffect`로 호출이 되고 있다.

  ```typescript
  useEffect(() => {
    updateQuestionSequence();
  }, [debouncedQuestions]);
  ```
  
  근데 이렇게 호출되다보니 최초 렌더링 시에도 불필요하게 해당 API가 한번 호출되고 있는데, 현재는 API call count를 이용해
  
  ```typescript
  if (countApiCalls === 0) {
    setCountApiCalls((prev) => prev + 1);
    return;
  }
  ```
  
  위와 같이 막아놓은 상태이다. 뭔가 더 좋은 방법 있을까..? 😭