### PR TITLE
Feat: implement create question page logics

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.52.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.52.1
+        version: 7.52.1(react@18.3.1)
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.4.0
@@ -4785,6 +4788,12 @@ packages:
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
+
+  react-hook-form@7.52.1:
+    resolution: {integrity: sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -11473,6 +11482,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.1.0
+
+  react-hook-form@7.52.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/src/app/(top)/_components/header.tsx
+++ b/src/app/(top)/_components/header.tsx
@@ -1,16 +1,23 @@
 'use client';
 import React from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter, useSelectedLayoutSegment } from 'next/navigation';
 
-const getHeaderText = (pathname: string): string => {
-  if (pathname.includes('workbookDetail')) return '문제집 상세';
-  if (pathname.includes('createQuestion')) return '문제 생성';
-  return 'not found';
+const HeaderItems: Record<string, { text: string }> = {
+  createQuestion: {
+    text: '문제 생성',
+  },
+  workbookDetail: {
+    text: '문제집 상세',
+  },
+  none: {
+    text: '잘못된 주소',
+  },
 };
 
 const Header = () => {
   const router = useRouter();
-  const pathname = usePathname();
+  const segment = useSelectedLayoutSegment();
+  const headerItem = HeaderItems[segment || 'none'];
 
   const handleBackClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     router.back();
@@ -19,7 +26,7 @@ const Header = () => {
   return (
     <div className="flex flex-row">
       <button onClick={handleBackClick}>go back</button>
-      <h1>{getHeaderText(pathname)}</h1>
+      <h1>{headerItem.text}</h1>
     </div>
   );
 };

--- a/src/app/(top)/createQuestion/@dialog/(.)intercepted/cancel-alert-dialog/page.tsx
+++ b/src/app/(top)/createQuestion/@dialog/(.)intercepted/cancel-alert-dialog/page.tsx
@@ -1,0 +1,7 @@
+import CancelAlertDialog from '@/app/(top)/createQuestion/_components/cancel-alert-dialog';
+
+const Page = () => {
+  return <CancelAlertDialog />;
+};
+
+export default Page;

--- a/src/app/(top)/createQuestion/@dialog/default.tsx
+++ b/src/app/(top)/createQuestion/@dialog/default.tsx
@@ -1,0 +1,5 @@
+const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/src/app/(top)/createQuestion/_components/cancel-alert-dialog.tsx
+++ b/src/app/(top)/createQuestion/_components/cancel-alert-dialog.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import AlertDialog from '@/components/alert-dialog';
+import { useRouter } from 'next/navigation';
+
+const DialogTexts = {
+  title: '문제 생성을 취소할까요?',
+  description: '작업 상황은 저장되지 않습니다.',
+};
+
+const CancelAlertDialog = () => {
+  const router = useRouter();
+
+  const confirmAction = () => {
+    router.replace('/redirect/createQuestion');
+  };
+
+  const cancelAction = () => {
+    router.back();
+  };
+
+  return (
+    <AlertDialog
+      title={DialogTexts.title}
+      description={DialogTexts.description}
+      confirmAction={confirmAction}
+      cancelAction={cancelAction}
+      preventDefault
+    />
+  );
+};
+
+export default CancelAlertDialog;

--- a/src/app/(top)/createQuestion/_components/cancel-alert-dialog.tsx
+++ b/src/app/(top)/createQuestion/_components/cancel-alert-dialog.tsx
@@ -5,7 +5,7 @@ import AlertDialog from '@/components/alert-dialog';
 import { useRouter } from 'next/navigation';
 
 const DialogTexts = {
-  title: '문제 생성을 취소할까요?',
+  title: '문제 사진을 재촬영할까요?',
   description: '작업 상황은 저장되지 않습니다.',
 };
 
@@ -13,7 +13,10 @@ const CancelAlertDialog = () => {
   const router = useRouter();
 
   const confirmAction = () => {
-    router.replace('/redirect/createQuestion');
+    router.back();
+    setTimeout(() => {
+      router.replace('/redirect/createQuestion');
+    }, 100);
   };
 
   const cancelAction = () => {

--- a/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
+++ b/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { UseFormRegister } from 'react-hook-form';
 import { QuestionBase } from '@/app/_lib/types';
 
-const AddExtraInfo = ({
+export const AddExtraInfo = ({
   register,
+  tags,
+  addTag,
+  removeTag,
 }: {
   register: UseFormRegister<QuestionBase>;
+  tags: string[];
+  addTag: (tag: string) => void;
+  removeTag: (tag: string) => void;
 }) => {
+  const [value, setValue] = useState<string>('');
+
   return (
     <form>
       <fieldset>
@@ -15,7 +23,20 @@ const AddExtraInfo = ({
       </fieldset>
       <fieldset>
         <legend>태그</legend>
-        <input />
+        <input onChange={(e) => setValue(e.target.value)} />
+        <button type="button" onClick={() => addTag(value)}>
+          추가
+        </button>
+        <div className="flex gap-4">
+          {tags.map((tag, idx) => (
+            <div key={idx} className="border-2">
+              <span>{tag}</span>
+              <button type="button" onClick={() => removeTag(tag)}>
+                X
+              </button>
+            </div>
+          ))}
+        </div>
       </fieldset>
       <fieldset>
         <legend>메모</legend>
@@ -24,5 +45,3 @@ const AddExtraInfo = ({
     </form>
   );
 };
-
-export default AddExtraInfo;

--- a/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
+++ b/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import { UseFormRegister } from 'react-hook-form';
+import { QuestionBase } from '@/app/_lib/types';
 
-const AddExtraInfo = () => {
+const AddExtraInfo = ({
+  register,
+}: {
+  register: UseFormRegister<QuestionBase>;
+}) => {
   return (
     <form>
       <fieldset>
         <legend>정답</legend>
-        <input />
+        <input {...register('answer')} />
       </fieldset>
       <fieldset>
         <legend>태그</legend>
@@ -13,7 +19,7 @@ const AddExtraInfo = () => {
       </fieldset>
       <fieldset>
         <legend>메모</legend>
-        <textarea />
+        <textarea {...register('memo')} />
       </fieldset>
     </form>
   );

--- a/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
+++ b/src/app/(top)/createQuestion/_components/content/add-extra-info.tsx
@@ -1,7 +1,22 @@
 import React from 'react';
 
 const AddExtraInfo = () => {
-  return <div>추가정보 입력하기</div>;
+  return (
+    <form>
+      <fieldset>
+        <legend>정답</legend>
+        <input />
+      </fieldset>
+      <fieldset>
+        <legend>태그</legend>
+        <input />
+      </fieldset>
+      <fieldset>
+        <legend>메모</legend>
+        <textarea />
+      </fieldset>
+    </form>
+  );
 };
 
 export default AddExtraInfo;

--- a/src/app/(top)/createQuestion/_components/content/check-convert.tsx
+++ b/src/app/(top)/createQuestion/_components/content/check-convert.tsx
@@ -1,7 +1,46 @@
 import React from 'react';
 
 const CheckConvert = () => {
-  return <div>변환 확인하기</div>;
+  return (
+    <form>
+      <fieldset>
+        <legend>문제설명</legend>
+        <textarea></textarea>
+      </fieldset>
+      <fieldset>
+        <legend>문제그림</legend>
+        <input type="file" />
+      </fieldset>
+      <fieldset>
+        <legend>문제 유형</legend>
+        <label>
+          <input type="radio" name="option" value="객관식" />
+          객관식
+        </label>
+        <label>
+          <input type="radio" name="option" value="단답형" />
+          단답형
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>선택지</legend>
+        <ul>
+          <li>
+            <input value="선택지1" />
+          </li>
+          <li>
+            <input value="선택지2" />
+          </li>
+          <li>
+            <input value="선택지3" />
+          </li>
+          <li>
+            <input value="선택지4" />
+          </li>
+        </ul>
+      </fieldset>
+    </form>
+  );
 };
 
 export default CheckConvert;

--- a/src/app/(top)/createQuestion/_components/content/check-convert.tsx
+++ b/src/app/(top)/createQuestion/_components/content/check-convert.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
-import { UseFormRegister } from 'react-hook-form';
-import { QuestionBase } from '@/app/_lib/types';
+import { UseFormRegister, FieldArrayWithId } from 'react-hook-form';
+import { Option, QuestionBase } from '@/app/_lib/types';
 
 const CheckConvert = ({
   register,
+  optionFields,
+  appendOption,
+  removeOption,
 }: {
   register: UseFormRegister<QuestionBase>;
+  optionFields: FieldArrayWithId[];
+  appendOption: (obj: Option) => void;
+  removeOption: (idx: number) => void;
 }) => {
+  const handleOptionAppendClick: React.MouseEventHandler<HTMLButtonElement> = (
+    e,
+  ) => {
+    appendOption({ value: '새로운 선택지' });
+  };
+
+  const handleOptionRemoveClick = (idx: number) => {
+    removeOption(idx);
+  };
+
   return (
     <form>
       <fieldset>
@@ -30,11 +46,22 @@ const CheckConvert = ({
       </fieldset>
       <fieldset>
         <legend>선택지</legend>
-        <ul>
-          <li>
-            <input readOnly value="선택지1" />
-          </li>
+        <ul className="flex flex-col gap-4">
+          {optionFields.map((field, idx) => (
+            <li key={field.id} className="flex border-2">
+              <input {...register(`options.${idx}.value`)} />
+              <button
+                type="button"
+                onClick={() => handleOptionRemoveClick(idx)}
+              >
+                삭제
+              </button>
+            </li>
+          ))}
         </ul>
+        <button type="button" onClick={handleOptionAppendClick}>
+          추가
+        </button>
       </fieldset>
     </form>
   );

--- a/src/app/(top)/createQuestion/_components/content/check-convert.tsx
+++ b/src/app/(top)/createQuestion/_components/content/check-convert.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UseFormRegister, FieldArrayWithId } from 'react-hook-form';
 import { Option, QuestionBase } from '@/app/_lib/types';
 
-const CheckConvert = ({
+export const CheckConvert = ({
   register,
   optionFields,
   appendOption,
@@ -66,5 +66,3 @@ const CheckConvert = ({
     </form>
   );
 };
-
-export default CheckConvert;

--- a/src/app/(top)/createQuestion/_components/content/check-convert.tsx
+++ b/src/app/(top)/createQuestion/_components/content/check-convert.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import { UseFormRegister } from 'react-hook-form';
+import { QuestionBase } from '@/app/_lib/types';
 
-const CheckConvert = () => {
+const CheckConvert = ({
+  register,
+}: {
+  register: UseFormRegister<QuestionBase>;
+}) => {
   return (
     <form>
       <fieldset>
         <legend>문제설명</legend>
-        <textarea></textarea>
+        <textarea {...register('statement')}></textarea>
       </fieldset>
       <fieldset>
         <legend>문제그림</legend>
@@ -14,11 +20,11 @@ const CheckConvert = () => {
       <fieldset>
         <legend>문제 유형</legend>
         <label>
-          <input type="radio" name="option" value="객관식" />
+          <input {...register('category')} type="radio" value="MULTIPLE" />
           객관식
         </label>
         <label>
-          <input type="radio" name="option" value="단답형" />
+          <input {...register('category')} type="radio" value="ESSAY" />
           단답형
         </label>
       </fieldset>
@@ -26,16 +32,7 @@ const CheckConvert = () => {
         <legend>선택지</legend>
         <ul>
           <li>
-            <input value="선택지1" />
-          </li>
-          <li>
-            <input value="선택지2" />
-          </li>
-          <li>
-            <input value="선택지3" />
-          </li>
-          <li>
-            <input value="선택지4" />
+            <input readOnly value="선택지1" />
           </li>
         </ul>
       </fieldset>

--- a/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
+++ b/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
@@ -1,20 +1,79 @@
-import React from 'react';
-import Step from '@/app/(top)/createQuestion/_components/progress/types';
+import React, { useState } from 'react';
+import {
+  Step,
+  StepProps,
+} from '@/app/(top)/createQuestion/_components/progress/types';
 import UploadPicture from '@/app/(top)/createQuestion/_components/content/upload-picture';
 import CheckConvert from '@/app/(top)/createQuestion/_components/content/check-convert';
 import AddExtraInfo from '@/app/(top)/createQuestion/_components/content/add-extra-info';
+import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progress/progress-change-footer';
+import Container from '@/components/container';
+import { useRouter } from 'next/navigation';
 
-const CreateQuestionContent = ({ currentStep }: { currentStep: Step }) => {
+const CreateQuestionContent = (props: StepProps) => {
+  const { currentStep, setToPrevStep, setToNextStep } = props;
+  const router = useRouter();
+  const [image, setInputImage] = useState<File | null>(null);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  const handleImageChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    setInputImage(e.target.files && e.target.files[0]);
+    e.target.files && setImageUrl(URL.createObjectURL(e.target.files[0]));
+  };
+
+  const handleLeftButtonClick = () => {
+    switch (currentStep) {
+      case 1:
+        setToNextStep();
+        break;
+      case 2:
+        setToPrevStep();
+        // input들 초기화
+        break;
+      case 3:
+        setToPrevStep();
+        break;
+    }
+  };
+
+  const handleRightButtonClick = () => {
+    switch (currentStep) {
+      case 1:
+        setToNextStep();
+        // 경고창
+        // 변환 로직 및 image null
+        break;
+      case 2:
+        setToNextStep();
+        break;
+      case 3:
+        router.push('question');
+        break;
+    }
+  };
+
   return (
-    <div>
-      {currentStep === 1 ? (
-        <UploadPicture />
-      ) : currentStep === 2 ? (
-        <CheckConvert />
-      ) : (
-        <AddExtraInfo />
-      )}
-    </div>
+    <Container className="flex flex-col">
+      <section className="flex-grow ">
+        {currentStep === 1 ? (
+          <UploadPicture
+            image={image}
+            imageUrl={imageUrl}
+            handleImageChange={handleImageChange}
+          />
+        ) : currentStep === 2 ? (
+          <CheckConvert />
+        ) : (
+          <AddExtraInfo />
+        )}
+      </section>
+
+      <ProgressChangeFooter
+        currentStep={currentStep}
+        handleLeftButtonClick={handleLeftButtonClick}
+        handleRightButtonClick={handleRightButtonClick}
+      />
+    </Container>
   );
 };
 

--- a/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
+++ b/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react';
 import { StepProps } from '@/app/(top)/createQuestion/_components/progress/types';
-import UploadPicture from './upload-picture';
-import CheckConvert from './check-convert';
-import AddExtraInfo from './add-extra-info';
+import {
+  UploadPicture,
+  CheckConvert,
+  AddExtraInfo,
+} from '@/app/(top)/createQuestion/_components/content';
 import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progress/progress-change-footer';
 import Container from '@/components/container';
-import { useRouter } from 'next/navigation';
 import { QuestionBase } from '@/app/_lib/types';
+
+import { useRouter } from 'next/navigation';
 import { useForm, useFieldArray } from 'react-hook-form';
+import { useImmer } from 'use-immer';
 
 const CreateQuestionContent = (props: StepProps) => {
   const { currentStep, setToPrevStep, setToNextStep } = props;
@@ -15,12 +19,7 @@ const CreateQuestionContent = (props: StepProps) => {
   const [image, setInputImage] = useState<File | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
 
-  const {
-    register,
-    handleSubmit,
-    control,
-    // formState: { erros }
-  } = useForm<QuestionBase>();
+  const { register, handleSubmit, control } = useForm<QuestionBase>();
   const {
     fields: optionFields,
     append: appendOption,
@@ -30,6 +29,16 @@ const CreateQuestionContent = (props: StepProps) => {
     name: 'options',
   });
 
+  const [tags, updateTags] = useImmer<string[]>([]);
+  const addTag = (tag: string) => {
+    updateTags((draft) => {
+      draft.push(tag);
+    });
+  };
+  const removeTag = (targetTag: string) => {
+    updateTags((draft) => draft.filter((tag) => tag !== targetTag));
+  };
+
   const handleImageChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputImage(e.target.files && e.target.files[0]);
     e.target.files && setImageUrl(URL.createObjectURL(e.target.files[0]));
@@ -37,7 +46,7 @@ const CreateQuestionContent = (props: StepProps) => {
 
   const createQuestion = handleSubmit((data) => {
     console.log(data);
-    // router.push('question');
+    console.log(tags);
   });
 
   const transformQuestion = async () => {
@@ -90,7 +99,12 @@ const CreateQuestionContent = (props: StepProps) => {
             removeOption={removeOption}
           />
         ) : (
-          <AddExtraInfo register={register} />
+          <AddExtraInfo
+            register={register}
+            tags={tags}
+            addTag={addTag}
+            removeTag={removeTag}
+          />
         )}
       </section>
 

--- a/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
+++ b/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Step,
-  StepProps,
-} from '@/app/(top)/createQuestion/_components/progress/types';
+import { StepProps } from '@/app/(top)/createQuestion/_components/progress/types';
 import UploadPicture from './upload-picture';
 import CheckConvert from './check-convert';
 import AddExtraInfo from './add-extra-info';
@@ -20,10 +17,7 @@ const CreateQuestionContent = (props: StepProps) => {
 
   const {
     register,
-    setValue,
     handleSubmit,
-    reset,
-    getValues,
     // formState: { erros },
   } = useForm<QuestionBase>();
 
@@ -48,9 +42,7 @@ const CreateQuestionContent = (props: StepProps) => {
         setToNextStep();
         break;
       case 2:
-        // 모달 경고. 진짜 뒤로 돌아갈꺼야?
-        setToPrevStep();
-        reset({ ...getValues });
+        router.replace('/createQuestion/intercepted/cancel-alert-dialog');
         break;
       case 3:
         setToPrevStep();

--- a/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
+++ b/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
@@ -3,12 +3,14 @@ import {
   Step,
   StepProps,
 } from '@/app/(top)/createQuestion/_components/progress/types';
-import UploadPicture from '@/app/(top)/createQuestion/_components/content/upload-picture';
-import CheckConvert from '@/app/(top)/createQuestion/_components/content/check-convert';
-import AddExtraInfo from '@/app/(top)/createQuestion/_components/content/add-extra-info';
+import UploadPicture from './upload-picture';
+import CheckConvert from './check-convert';
+import AddExtraInfo from './add-extra-info';
 import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progress/progress-change-footer';
 import Container from '@/components/container';
 import { useRouter } from 'next/navigation';
+import { QuestionBase } from '@/app/_lib/types';
+import { useForm } from 'react-hook-form';
 
 const CreateQuestionContent = (props: StepProps) => {
   const { currentStep, setToPrevStep, setToNextStep } = props;
@@ -16,9 +18,28 @@ const CreateQuestionContent = (props: StepProps) => {
   const [image, setInputImage] = useState<File | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
 
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    reset,
+    getValues,
+    // formState: { erros },
+  } = useForm<QuestionBase>();
+
   const handleImageChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputImage(e.target.files && e.target.files[0]);
     e.target.files && setImageUrl(URL.createObjectURL(e.target.files[0]));
+  };
+
+  const createQuestion = handleSubmit((data) => {
+    console.log(data);
+    // router.push('question');
+  });
+
+  const transformQuestion = async () => {
+    console.log('문제 변환');
+    setToNextStep();
   };
 
   const handleLeftButtonClick = () => {
@@ -27,8 +48,9 @@ const CreateQuestionContent = (props: StepProps) => {
         setToNextStep();
         break;
       case 2:
+        // 모달 경고. 진짜 뒤로 돌아갈꺼야?
         setToPrevStep();
-        // input들 초기화
+        reset({ ...getValues });
         break;
       case 3:
         setToPrevStep();
@@ -39,15 +61,13 @@ const CreateQuestionContent = (props: StepProps) => {
   const handleRightButtonClick = () => {
     switch (currentStep) {
       case 1:
-        setToNextStep();
-        // 경고창
-        // 변환 로직 및 image null
+        transformQuestion();
         break;
       case 2:
         setToNextStep();
         break;
       case 3:
-        router.push('question');
+        createQuestion();
         break;
     }
   };
@@ -62,9 +82,9 @@ const CreateQuestionContent = (props: StepProps) => {
             handleImageChange={handleImageChange}
           />
         ) : currentStep === 2 ? (
-          <CheckConvert />
+          <CheckConvert register={register} />
         ) : (
-          <AddExtraInfo />
+          <AddExtraInfo register={register} />
         )}
       </section>
 

--- a/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
+++ b/src/app/(top)/createQuestion/_components/content/create-question-content.tsx
@@ -7,7 +7,7 @@ import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progres
 import Container from '@/components/container';
 import { useRouter } from 'next/navigation';
 import { QuestionBase } from '@/app/_lib/types';
-import { useForm } from 'react-hook-form';
+import { useForm, useFieldArray } from 'react-hook-form';
 
 const CreateQuestionContent = (props: StepProps) => {
   const { currentStep, setToPrevStep, setToNextStep } = props;
@@ -18,8 +18,17 @@ const CreateQuestionContent = (props: StepProps) => {
   const {
     register,
     handleSubmit,
-    // formState: { erros },
+    control,
+    // formState: { erros }
   } = useForm<QuestionBase>();
+  const {
+    fields: optionFields,
+    append: appendOption,
+    remove: removeOption,
+  } = useFieldArray<QuestionBase, 'options'>({
+    control,
+    name: 'options',
+  });
 
   const handleImageChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputImage(e.target.files && e.target.files[0]);
@@ -42,7 +51,7 @@ const CreateQuestionContent = (props: StepProps) => {
         setToNextStep();
         break;
       case 2:
-        router.replace('/createQuestion/intercepted/cancel-alert-dialog');
+        router.push('/createQuestion/intercepted/cancel-alert-dialog');
         break;
       case 3:
         setToPrevStep();
@@ -74,7 +83,12 @@ const CreateQuestionContent = (props: StepProps) => {
             handleImageChange={handleImageChange}
           />
         ) : currentStep === 2 ? (
-          <CheckConvert register={register} />
+          <CheckConvert
+            register={register}
+            optionFields={optionFields}
+            appendOption={appendOption}
+            removeOption={removeOption}
+          />
         ) : (
           <AddExtraInfo register={register} />
         )}

--- a/src/app/(top)/createQuestion/_components/content/index.ts
+++ b/src/app/(top)/createQuestion/_components/content/index.ts
@@ -1,0 +1,3 @@
+export * from './add-extra-info';
+export * from './check-convert';
+export * from './upload-picture';

--- a/src/app/(top)/createQuestion/_components/content/upload-picture.tsx
+++ b/src/app/(top)/createQuestion/_components/content/upload-picture.tsx
@@ -8,7 +8,7 @@ type Props = {
   handleImageChange: React.ChangeEventHandler<HTMLInputElement>;
 };
 
-const UploadPicture = (props: Props) => {
+export const UploadPicture = (props: Props) => {
   const { image, imageUrl, handleImageChange } = props;
   const hiddenInputRef = useRef<HTMLInputElement>(null);
 
@@ -41,5 +41,3 @@ const UploadPicture = (props: Props) => {
     </div>
   );
 };
-
-export default UploadPicture;

--- a/src/app/(top)/createQuestion/_components/content/upload-picture.tsx
+++ b/src/app/(top)/createQuestion/_components/content/upload-picture.tsx
@@ -1,7 +1,45 @@
-import React from 'react';
+'use client';
 
-const UploadPicture = () => {
-  return <div>문제 등록하기</div>;
+import React, { useEffect, useRef, useState } from 'react';
+
+type Props = {
+  image: File | null;
+  imageUrl: string | null;
+  handleImageChange: React.ChangeEventHandler<HTMLInputElement>;
+};
+
+const UploadPicture = (props: Props) => {
+  const { image, imageUrl, handleImageChange } = props;
+  const hiddenInputRef = useRef<HTMLInputElement>(null);
+
+  const handleDisplayedButtonClick: React.MouseEventHandler<
+    HTMLButtonElement
+  > = () => {
+    hiddenInputRef.current?.click();
+  };
+
+  return (
+    <div>
+      <button
+        className="w-32 h-32 bg-brand-blue-heavy"
+        onClick={handleDisplayedButtonClick}
+      >
+        파일 업로드
+      </button>
+      <div className="bg-red-500 w-40 h-40">
+        {imageUrl && <img src={imageUrl} />}
+      </div>
+      <form>
+        <input
+          ref={hiddenInputRef}
+          className="hidden"
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+        />
+      </form>
+    </div>
+  );
 };
 
 export default UploadPicture;

--- a/src/app/(top)/createQuestion/_components/progress/progress-change-footer.tsx
+++ b/src/app/(top)/createQuestion/_components/progress/progress-change-footer.tsx
@@ -1,31 +1,38 @@
 import React from 'react';
-import Step from '@/app/(top)/createQuestion/_components/progress/types';
+import { Step } from '@/app/(top)/createQuestion/_components/progress/types';
+
+const ButtonText = {
+  1: {
+    left: '직접 입력하기',
+    right: '사진 변환하기',
+  },
+  2: {
+    left: '사진 다시찍기',
+    right: '다음으로',
+  },
+  3: {
+    left: '이전으로',
+    right: '문제 생성',
+  },
+};
 
 const ProgressChangeFooter = ({
+  handleLeftButtonClick,
+  handleRightButtonClick,
   currentStep,
-  setToNextStep,
-  setToPrevStep,
 }: {
+  handleLeftButtonClick: () => void;
+  handleRightButtonClick: () => void;
   currentStep: Step;
-  setToNextStep: () => void;
-  setToPrevStep: () => void;
 }) => {
-  const handlePrevButtonClick: React.MouseEventHandler<
-    HTMLButtonElement
-  > = () => {
-    setToPrevStep();
-  };
-
-  const handleNextButtonClick: React.MouseEventHandler<
-    HTMLButtonElement
-  > = () => {
-    setToNextStep();
-  };
-
   return (
-    <div className="absolute bottom-0 left-0 w-full">
-      <button onClick={handlePrevButtonClick}>이전으로</button>
-      <button onClick={handleNextButtonClick}>다음으로</button>
+    <div className="w-full">
+      <button onClick={handleLeftButtonClick}>
+        {ButtonText[currentStep].left}
+      </button>
+      <button onClick={handleRightButtonClick}>
+        {ButtonText[currentStep].right}
+      </button>
     </div>
   );
 };

--- a/src/app/(top)/createQuestion/_components/progress/types.ts
+++ b/src/app/(top)/createQuestion/_components/progress/types.ts
@@ -1,3 +1,7 @@
-type Step = 1 | 2 | 3;
+export type Step = 1 | 2 | 3;
 
-export default Step;
+export type StepProps = {
+  currentStep: Step;
+  setToNextStep: () => void;
+  setToPrevStep: () => void;
+};

--- a/src/app/(top)/createQuestion/intercepted/cancel-alert-dialog/page.tsx
+++ b/src/app/(top)/createQuestion/intercepted/cancel-alert-dialog/page.tsx
@@ -1,0 +1,7 @@
+import CancelAlertDialog from '@/app/(top)/createQuestion/_components/cancel-alert-dialog';
+
+const Page = () => {
+  return <CancelAlertDialog />;
+};
+
+export default Page;

--- a/src/app/(top)/createQuestion/layout.tsx
+++ b/src/app/(top)/createQuestion/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Layout = ({
+  children,
+  dialog,
+}: {
+  children: React.ReactNode;
+  dialog: React.ReactNode;
+}) => {
+  return (
+    <>
+      {children}
+      {dialog}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/app/(top)/createQuestion/page.tsx
+++ b/src/app/(top)/createQuestion/page.tsx
@@ -3,8 +3,9 @@
 import React, { useState } from 'react';
 import Progress from '@/app/(top)/createQuestion/_components/progress/progress';
 import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progress/progress-change-footer';
-import Step from './_components/progress/types';
+import { Step } from './_components/progress/types';
 import CreateQuestionContent from '@/app/(top)/createQuestion/_components/content/create-question-content';
+import Container from '@/components/container';
 
 const Page = () => {
   const [currentStep, setCurrentStep] = useState<Step>(1);
@@ -24,15 +25,16 @@ const Page = () => {
   };
 
   return (
-    <div className="relative w-full flex-grow">
+    <Container className="flex flex-col">
       <Progress currentStep={currentStep} />
-      <CreateQuestionContent currentStep={currentStep} />
-      <ProgressChangeFooter
-        currentStep={currentStep}
-        setToNextStep={setToNextStep}
-        setToPrevStep={setToPrevStep}
-      />
-    </div>
+      <section className="flex-grow flex flex-col">
+        <CreateQuestionContent
+          currentStep={currentStep}
+          setToNextStep={setToNextStep}
+          setToPrevStep={setToPrevStep}
+        />
+      </section>
+    </Container>
   );
 };
 

--- a/src/app/(top)/createQuestion/page.tsx
+++ b/src/app/(top)/createQuestion/page.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react';
 import Progress from '@/app/(top)/createQuestion/_components/progress/progress';
-import ProgressChangeFooter from '@/app/(top)/createQuestion/_components/progress/progress-change-footer';
 import { Step } from './_components/progress/types';
 import CreateQuestionContent from '@/app/(top)/createQuestion/_components/content/create-question-content';
 import Container from '@/components/container';

--- a/src/app/(top)/layout.tsx
+++ b/src/app/(top)/layout.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode } from 'react';
 import Header from '@/app/(top)/_components/header';
+import Container from '@/components/container';
 
 const Layout = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="w-full h-full flex flex-col">
+    <Container className="w-full h-full flex flex-col">
       <Header />
-      {children}
-    </div>
+      <section className="flex-grow">{children}</section>
+    </Container>
   );
 };
 

--- a/src/app/_lib/dummy.ts
+++ b/src/app/_lib/dummy.ts
@@ -148,14 +148,14 @@ export const Dummy_Workbook: Workbook = {
   modifiedAt: new Date('2023-09-13'),
 };
 
-export const Dummy_Questions: Question[] = [
+export const Dummy_Questions: Omit<Question, 'memo'>[] = [
   {
     id: '0',
     statement: '이 문제는 어디서부터 건너왔으며 어디서 나온다.',
     options: ['원', '삼각형', '직사각형', '오각형'],
     image: '이상한 url',
     answer: '4',
-    category: '객관식',
+    category: 'MULTIPLE',
     tags: ['미적분II', '3번틀린문제'],
     modifiedAt: new Date('2023-09-13'),
   },
@@ -165,20 +165,20 @@ export const Dummy_Questions: Question[] = [
     options: ['30', '45', '60', '90'],
     image: '이상한 url',
     answer: '1',
-    category: '객관식',
+    category: 'MULTIPLE',
     tags: ['수학II', '이건태그얌'],
     modifiedAt: new Date('2023-09-13'),
   },
 ];
 
-export const Dummy_Questions_In_Workbook: QuestionInWorkbook[] = [
+export const Dummy_Questions_In_Workbook: Omit<QuestionInWorkbook, 'memo'>[] = [
   {
     id: '0',
     statement: '이 문제는 어디서부터 건너왔으며 어디서 나온다.',
     options: ['원', '삼각형', '직사각형', '오각형'],
     image: '이상한 url',
     answer: '4',
-    category: '객관식',
+    category: 'MULTIPLE',
     tags: ['미적분II', '3번틀린문제'],
     sequence: 1,
     modifiedAt: new Date('2023-09-13'),
@@ -189,7 +189,7 @@ export const Dummy_Questions_In_Workbook: QuestionInWorkbook[] = [
     options: ['30', '45', '60', '90'],
     image: '이상한 url',
     answer: '1',
-    category: '객관식',
+    category: 'MULTIPLE',
     tags: ['수학II', '이건태그얌'],
     sequence: 2,
     modifiedAt: new Date('2023-09-13'),

--- a/src/app/_lib/types.ts
+++ b/src/app/_lib/types.ts
@@ -7,9 +7,13 @@ export type Workbook = {
   modifiedAt: Date;
 };
 
+export type Option = {
+  value: string;
+};
+
 export type QuestionBase = {
   statement: string;
-  options: string[];
+  options: Option[];
   image: string;
   answer: string;
   category: Category;

--- a/src/app/_lib/types.ts
+++ b/src/app/_lib/types.ts
@@ -7,22 +7,25 @@ export type Workbook = {
   modifiedAt: Date;
 };
 
-export type Question = {
-  id: string;
+export type QuestionBase = {
   statement: string;
-  // options: {
-  //   [key: string]: string;
-  // };
   options: string[];
   image: string;
   answer: string;
-  category: string;
+  category: Category;
   tags: string[];
-  modifiedAt: Date;
+  memo: string;
 };
+
+export type Question = {
+  id: string;
+  modifiedAt: Date;
+} & QuestionBase;
 
 export type QuestionInWorkbook = {
   sequence: number;
 } & Question;
 
 export type Status = 'loading' | 'error' | 'success';
+
+export type Category = 'MULTIPLE' | 'ESSAY';

--- a/src/app/redirect/[url]/page.tsx
+++ b/src/app/redirect/[url]/page.tsx
@@ -1,0 +1,7 @@
+import { redirect, RedirectType } from 'next/navigation';
+
+const Page = ({ params }: { params: { url: string } }) => {
+  redirect(`/${params.url}`, RedirectType.replace);
+};
+
+export default Page;

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,20 +1,37 @@
-'use client';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
 
-import React, { useEffect, useState } from 'react';
-import CtrlTextInput from '@/components/custom/ctrl-text-input';
-
-const Page = () => {
-  const [input, setInput] = useState<string>('');
-
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    setInput(e.target.value);
-  };
+function AlertDialogDemo() {
   return (
-    <div>
-      <p>{`Parent Component State : ${input}`}</p>
-      <CtrlTextInput allowClear value={input} onChange={handleChange} />
-    </div>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show Dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. This will permanently delete your
+            account and remove your data from our servers.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
-};
+}
 
-export default Page;
+export default AlertDialogDemo;

--- a/src/components/alert-dialog.tsx
+++ b/src/components/alert-dialog.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import {
+  AlertDialog as AlertDialogContainer,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type ClickStatus = 'NotYet' | 'Confirm' | 'Cancel';
+
+const AlertDialog = ({
+  title,
+  description,
+  confirmAction,
+  cancelAction,
+  preventDefault = false,
+}: {
+  title: string;
+  description: string;
+  confirmAction?: () => void;
+  cancelAction?: () => void;
+  preventDefault?: boolean;
+}) => {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [clickStatus, setClickStatus] = useState<ClickStatus>('NotYet');
+
+  const handleConfirmClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setClickStatus('Confirm');
+    setIsOpen(false);
+  };
+
+  const handleCancelClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setClickStatus('Cancel');
+    setIsOpen(false);
+  };
+
+  const action = async () => {
+    await new Promise((res) => setTimeout(res, 400));
+    if (clickStatus === 'Confirm') confirmAction && confirmAction();
+    else if (clickStatus === 'Cancel') cancelAction && cancelAction();
+
+    preventDefault || router.back();
+  };
+
+  useEffect(() => {
+    if (isOpen) return;
+    (async () => {
+      await action();
+    })();
+  }, [isOpen]);
+
+  return (
+    <AlertDialogContainer open={isOpen}>
+      <AlertDialogContent className="bg-white w-4/5 rounded-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleCancelClick}>
+            취소
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirmClick}>
+            확인
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialogContainer>
+  );
+};
+
+export default AlertDialog;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,8 +24,22 @@ module.exports = {
       },
       backgroundImage: {
         'banner-bg' : 'linear-gradient(95.84deg, #BAF2EC 0%, #BCE7FF 97.09%)',
-      }
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
     },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
### 🤔 Description
* 문제 생성 페이지에서 API 관련 로직을 제외한 폼 및 화면 전환과 관련된 로직을 구현한다.
* 문제 생성은 3단계로 이루어진 만큼 내부적으로 단계를 `state`로 관리한다. (#28 참고)
* 또한 문제 생성 시, 폼에 담겨 있던 모든 내용을 전송해야 하므로 최상위 컴포넌트에서 폼의 내용을 모두 관리하도록 구현했으며, 이를 위해 [React Hook Form](https://react-hook-form.com/docs) 라이브러리를 도입했다.

### 👋 Related issues
* **Close** #29 

### 🔍 Details

* 문제 생성 페이지의 핵심 로직은 모두 `create-question-content.tsx`에 포함되어 있다. 해당 컴포넌트가 수행하는 역할은 다음과 같다.

  1. 문제 생성 단계를 `currentStep`이라는 state variable로 관리하며 해당 변수에 따라 서로 다른 화면을 렌더링한다.
      ```ts
      <section className="flex-grow ">
        {currentStep === 1 ? (
          <UploadPicture/>
        ) : currentStep === 2 ? (
          <CheckConvert/>
        ) : (
          <AddExtraInfo/>
        )}
      </section>
      ```
  
  2. 현재 단계 및 화면 전환 로직을 `<ProgressChangeFooter>` component로 전달한다.
      ```ts
      <ProgressChangeFooter
        currentStep={currentStep}
        handleLeftButtonClick={handleLeftButtonClick}
        handleRightButtonClick={handleRightButtonClick}
      />
      ```
  3. 세 단계에 걸친 모든 입력 값들을 state로 관리한다.
  
  확실히 하나의 컴포넌트 안에 너무 많은 역할이 존재하나, 최상위 컴포넌트의 어쩔 수 없는 숙명이었다. 전역 상태도 고려해봤지만 확실한 이유를 찾을 수 없어 우선 주먹구구식으로 구현한 상태이다..🫣

* **`upload-picture.tsx`**

  문제 생성 페이지 1단계에 해당하는 화면으로 변환 전 사진 업로드 및 업로드한 사진의 미리보기를 보여준다.
  
  <p align="center">
  <img width="30%" alt="스크린샷 2024-07-29 오후 8 14 38" src="https://github.com/user-attachments/assets/c7c1765e-ba8e-498a-ac82-8f78ca02a3e8">
  </p>
  
  업로드된 사진을 저장할 `image` state, 업로드한 사진의 미리보기를 위한 `imageUrl` state를 `create-question-content.tsx`로 부터 전달받는다.
  
  언급할 점은, 파일 업로드를 위한 `<input type="file"/>`은 스타일링이 쉽지가 않기 때문에, 실제 `<input>`을 숨기고 스타일링된 버튼을 생성하여 해당 버튼에 클릭 이벤트가 발생하는 경우, 숨긴 `<input>`에 클릭 이벤트가 발생하도록 구현했다.

* **`check-convert.tsx`** & **`add-extra-info.tsx`**

  각 각 문제 생성 2단계와 3단계에 대한 화면으로, `설명`, `사진`, `유형`, `선택지`, `정답`, `태그`, `메모` 총 6개의 관리할 폼이 존재한다. 이에 복잡한 state 관리가 예상되어 `React Hook Form` 라이브러리를 이용했다.

  * **`선택지`와 `태그`를 제외한 나머지 폼**은 모두 [`useForm`](https://react-hook-form.com/docs/useform) hook의 `register`로 관리한다.
      
      ```ts
      <legend>문제설명</legend>
              <textarea {...register('statement')}></textarea>
      ```
    
    와 같이 단순히 알맞은 key(name)값을 가진 `register`만을 넘겨주면 자동으로 input value가 관리되는 기가 막히고 코가 막히는 라이브러리이다. 🤯

  * `선택지`는 아래 화면과 같이 동작하는 dynamic form이다. 따라서 [`useFieldArray`](https://react-hook-form.com/docs/usefieldarray) hook을 이용했다.
  
     <p align="center"><img width="30%" src="https://github.com/user-attachments/assets/37282efa-8caa-4aab-a002-01cfe4287e7b"/></p>
    
    라이브러리 사용은 매우 직관적이고 쉬웠으나 typescript를 사용 시에, type과 관련된 문제가 조금 발생한다. [React Hook Form - TypeScript](https://react-hook-form.com/ts)에 자세한 설명들이 나와있으므로 앞으로도 참고하자. 

  * `태그`는 #24 의 검색화면가 거의 동일하다. 태그폼은 특정 버튼을 누르는 순간 태그가 추가되는 형식이므로 전과 달리 input value들을 추적하고 있을 필요가 없다. 물론 `useForm` hook의 리턴값에 `setValue`가 존재하지만 차라리 따로 state로 관리하는 게 나을 것 같았다.
    
    또한 태그 추가 로직도 문제 조회 화면, 문제 추가 화면 등 여러번 사용되므로 custom hook으로 추출하려 했으나 기존 문제 조회 화면 태그 추가 로직은 키워드 관련 로직도 섞여 있어 hook 추출에 실패했다.

* 화면의 상단에 존재하는 `<Header>` component는 `(top)` directory 하단의 layout이다. 따라서 `(top)` 이후의 url에 대하 알맞는 문구를 출력해야 하는데, 이전에는 `usePathname`과 `contain`으로 구현하였으나 [`useSelectedLayoutSegment`](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segment) hook을 알게 되어 이를 이용했다.

* `alert-dialog.tsx` component를 재사용성 확보를 위해 새롭게 구현했다. `confirmAction`과 `cancelAction`을 prop으로 받아 버튼 클릭에 따라 둘 중 하나를 수행하고, 기본 동작인 `router.back()`을 수행한다. 해당 기본 동작은 `preventDefault` prop을 전달하여 막을 수 있도록 구현했다.

### 🐛 Bugs

* 이번 구현 중 가장 골머리를 썩게한 원인은 dialog이다. 현재 dialog는 컴포넌트 분리를 위해 parallel & intercepting routes를 사용하고 있다. 따라서 이번에도 #26 의 Bugs에 게시한 내용이 똑같이 발생하고 있다.

  <p align="center">
  <img width="30%" alt="스크린샷 2024-07-29 오후 11 30 04" src="https://github.com/user-attachments/assets/5450c67a-5bf0-4bd3-8491-8c3c8284ba6c">
  </p>

* 이에 더불어 dialog로 인한 문제가 하나 더있는데 바로 페이지 네비게이션 문제이다. 문제 생성 페이지의 경우 `currentStep` state를 통해 페이지가 관리되는데 dialog의 경우 `currentStep`의 조작이 불가하다. 다행히도 [useRouter - preserving state](https://nextjs.org/docs/pages/api-reference/functions/use-router#resetting-state-after-navigation)에 나와있듯이 dialog url로 넘어갔다가 `router.back()`이 수행되어도 state가 preserve 되기 때문에 해당 경고 화면의 취소에는 큰 문제가 없다.

* 문제는 확인이다. 확인의 경우 `currentStep`이 다시 초기화되어야 하므로 re-rendering이 필요하다. 따라서 이를 위해 

  ```ts
  // createQuestion/_components/cancel-alert-dialog.tsx
  const confirmAction = () => {
    router.back();
    setTimeout(() => {
      router.replace('/redirect/createQuestion');
    }, 100);
  };
  ```
  와 같이 `redirect`용 페이지를 새롭게 만들었다. `app/redirect/[url]/page.tsx`. 추가로 `router.back()`을 확정적으로 먼저 수행 시키기 위해 `setTimeout`까지 추가했는데 정말 최악의 코드라고 생각한다.

* 위 문제를 해결하는 것은 크게 두 가지 방법이 있다.
  1. 곱게 모달을 그냥 컴포넌트 내에 위치시킨다.
  2. `<Header>`의 돌아가기 버튼에 `router.back`이 아니라 manual하게 돌아갈 url에 대해 `router.push`를 수행한다.

### 💬 Others
* `type Category = 'MULTIPLE' | 'ESSAY'` 이런 타입에 대해 `enum`을 쓰는 것은 별로인가..?
* `create-question-content.tsx` 역할 분리 어떻게..?